### PR TITLE
Adding calibration script to tweak the "distance"

### DIFF
--- a/calibrate.py
+++ b/calibrate.py
@@ -1,0 +1,42 @@
+"""
+Return the estimated distance based on a real event and the actual mph
+
+Usage:
+    calibrate.py <eventfile> --mph=<mph>
+
+Options:
+    -h --help     Show this screen.
+"""
+
+import logging
+import json
+import docopt
+import math
+import pathlib
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s %(message)s'
+)
+# Load arguments
+args = docopt.docopt(__doc__)
+
+# Get the actual mph
+mph = int(args['--mph'])
+
+# Load the event data
+event_data = None
+with open(pathlib.Path(args['<eventfile>']), 'r') as json_file:
+  event_data = json.load(json_file)
+
+# Figure out the speed
+total_distance = 0
+direction = None
+for frame, event in enumerate(event_data):
+    direction = event['dir']
+    # MATH!
+    distance = ((((mph / 0.681818) * event['secs']) / event['delta']) * float(event['image_width'])) / (2 * (math.tan(math.radians(event['fov'] * 0.5))))
+    total_distance += distance
+    logging.info('Frame {:2.0f}: {:1.2f}sec {:4.2f}px {:2.0f}mph == {:4.2f} distance'.format(frame, event['secs'], event['delta'], event['mph'], distance))
+
+logging.info('Updated distance for {}: {:4.2f}'.format(direction, total_distance / len(event_data)))

--- a/speed-camera.py
+++ b/speed-camera.py
@@ -1,9 +1,9 @@
-# CarSpeed Version 4.0
+# speed-camera v4.0
 """
 Script to capture moving car speed
 
 Usage:
-    carspeed.py [preview] [--config=<file>]
+    speed-camera.py [preview] [--config=<file>]
 
 Options:
     -h --help     Show this screen.
@@ -567,12 +567,15 @@ for frame in camera.capture_continuous(capture, format="bgr", use_video_port=Tru
             if state == TRACKING:
                 abs_chg = 0
                 mph = 0
+                distance = 0
                 if x >= last_x:
                     direction = LEFT_TO_RIGHT
+                    distance = cfg.l2r_distance
                     abs_chg = (x + w) - (initial_x + initial_w)
                     mph = get_speed(abs_chg, l2r_ft_per_pixel, secs)
                 else:
                     direction = RIGHT_TO_LEFT
+                    distance = cfg.r2l_distance
                     abs_chg = initial_x - x
                     mph = get_speed(abs_chg, r2l_ft_per_pixel, secs)
 
@@ -583,13 +586,21 @@ for frame in camera.capture_continuous(capture, format="bgr", use_video_port=Tru
                 events.append({
                     'image': image.copy(),
                     'ts': timestamp,
+                    # Location of object
                     'x': x,
                     'y': y,
                     'w': w,
                     'h': h,
-                    'delta': abs_chg,
-                    'area': biggest_area,
+                    # Speed
                     'mph': mph,
+                    # MPH is calculated from secs, delta, fov, distance, image_width
+                    'fov': cfg.fov,
+                    'image_width': cfg.image_width,
+                    'distance': distance,
+                    'secs': secs,
+                    'delta': abs_chg,
+                    # Other useful data
+                    'area': biggest_area,
                     'dir': str_direction(direction),
                 })
 


### PR DESCRIPTION
Super simple tool to adjust your distance settings based on real speeds of cars.

```bash
$ python3 calibrate.py logs/2020-07-30_16:52:13.285767-21mph-99.json --mph=36
2020-07-30 19:07:33,141 Frame  0: 0.13sec 79.00px 21mph == 75.98 distance
2020-07-30 19:07:33,141 Frame  1: 0.27sec 156.00px 21mph == 76.64 distance
2020-07-30 19:07:33,141 Frame  2: 0.41sec 238.00px 21mph == 77.98 distance
2020-07-30 19:07:33,141 Frame  3: 0.57sec 338.00px 22mph == 75.23 distance
2020-07-30 19:07:33,141 Frame  4: 0.70sec 416.00px 21mph == 75.40 distance
2020-07-30 19:07:33,141 Frame  5: 0.83sec 494.00px 21mph == 75.59 distance
2020-07-30 19:07:33,141 Frame  6: 0.97sec 573.00px 21mph == 75.65 distance
2020-07-30 19:07:33,141 Frame  7: 1.10sec 654.00px 21mph == 75.36 distance
2020-07-30 19:07:33,141 Frame  8: 1.23sec 731.00px 21mph == 75.61 distance
2020-07-30 19:07:33,141 Frame  9: 1.37sec 813.00px 21mph == 75.64 distance
2020-07-30 19:07:33,141 Frame 10: 1.50sec 863.00px 21mph == 77.88 distance
2020-07-30 19:07:33,141 Updated distance for RTL: 76.09
```